### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
+[![Board Status](https://dev.azure.com/SimplyForPeople/e776c035-38fb-4637-b5e3-cdf8045e1b6b/a1bfe18e-9299-406a-92a7-99adecc238f8/_apis/work/boardbadge/b73b5a3c-2820-4926-a28a-151cfb3e6a08)](https://dev.azure.com/SimplyForPeople/e776c035-38fb-4637-b5e3-cdf8045e1b6b/_boards/board/t/a1bfe18e-9299-406a-92a7-99adecc238f8/Microsoft.RequirementCategory)
 # SimpleNotes
 Simple application for Notes


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#10](https://dev.azure.com/SimplyForPeople/e776c035-38fb-4637-b5e3-cdf8045e1b6b/_workitems/edit/10). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.